### PR TITLE
Add initial workflow to scan images with Lacework scan

### DIFF
--- a/.github/actions/action-lacework-scan/action.yml
+++ b/.github/actions/action-lacework-scan/action.yml
@@ -1,0 +1,130 @@
+name: 'Run Lacework image scan'
+description: 'Scan the provided image with Lacework scan tool and return a JSON with the results.'
+
+inputs:
+  image:
+    description: 'Full URL of the image to scan.'
+    required: true
+  docker-username:
+    description: 'Docker username.'
+    required: true
+  docker-password:
+    description: 'Docker password.'
+    required: true
+  lw-account-name:
+    description: 'Lacework account name.'
+    required: true
+  lw-access-token:
+    description: 'Lacework access token.'
+    required: true
+  severity-filter:
+    description: 'Specify severities of CVEs to be included in the result, in CSV format, e.g. "Critical,High,Medium,Low,Info". (Default: "Critical,High")'
+    default: 'Critical,High'
+  save-results-in-lacework:
+    description: 'Save results to Lacework. (Default: false)'
+    default: 'false'
+  debug-mode:
+    description: 'Set to "true" to enable debug mode. It generates extra artifacts with partial results. (Default: false)'
+    default: 'false'
+
+outputs:
+  result-json:
+    description: 'Lacework scan result in JSON format.'
+    value: ${{ steps.process-result.outputs.result-json }}
+
+runs:
+  using: "composite"
+  steps:
+  - name: Prepare input
+    id: prepare-input
+    shell: bash
+    run: |
+      echo "image-name=$(echo "${{ inputs.image }}" | cut -d: -f1)" >> $GITHUB_OUTPUT
+      echo "image-tag=$(echo "${{ inputs.image }}" | cut -d: -f2)" >> $GITHUB_OUTPUT
+      echo "safe-image-id=$(echo "${{ inputs.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')" >> $GITHUB_OUTPUT
+
+  - name: Docker login
+    uses: docker/login-action@v2
+    with:
+      username: ${{ inputs.docker-username }}
+      password: ${{ inputs.docker-password }}
+
+  - name: Docker pull
+    shell: bash
+    run: docker pull ${{ inputs.image }}
+
+  - name: Scan
+    uses: lacework/lw-scanner-action@v1.1.1
+    with:
+      LW_ACCOUNT_NAME: ${{ inputs.lw-account-name }}
+      LW_ACCESS_TOKEN: ${{ inputs.lw-access-token }}
+      IMAGE_NAME: ${{ steps.prepare-input.outputs.image-name }}
+      IMAGE_TAG: ${{ steps.prepare-input.outputs.image-tag }}
+      SCAN_LIBRARY_PACKAGES: true
+      SAVE_RESULTS_IN_LACEWORK: ${{ inputs.save-results-in-lacework }}
+      SAVE_BUILD_REPORT: ${{ inputs.debug-mode }}
+      BUILD_REPORT_FILE_NAME: ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-report.html
+      LW_SCANNER_ENABLE_DEBUGGING: ${{ inputs.debug-mode }}
+
+
+  - name: Process result
+    id: process-result
+    shell: bash
+    run: |
+      fullJson=$(find ./evaluations -name 'evaluation_*.json' 2>/dev/null)
+      echo "Parsing result from: $fullJson"
+
+      # Check image is the same.
+      imageName=$(cat $fullJson | jq -r '.cve.image.image_info.repository')
+      imageTag=$(cat $fullJson | jq -r '.cve.image.image_info.tags[0]')
+      if [ "$imageName" != "${{ steps.prepare-input.outputs.image-name }}" ] || [ "$imageTag" != "${{ steps.prepare-input.outputs.image-tag }}" ]; then
+        >&2 echo "Image mismatch: ${imageName}:${imageTag} != ${{ steps.prepare-input.outputs.image-name }}:${{ steps.prepare-input.outputs.image-tag }}"
+        exit 1
+      fi
+      
+      # Filter JSON by deleting vulnerabilities with unwanted severities.
+      filteredJson="${{ steps.prepare-input.outputs.safe-image-id }}.filtered.json"
+      jq 'del(.cve.image.image_layers[].packages[].vulnerabilities[] | select(.severity != "Critical" and  .severity != "High" ))
+          | del(.cve.image.image_layers[].packages[] | select(.vulnerabilities == []))
+          | del(.cve.image.image_layers[] | select(.packages == []))' \
+        $fullJson > $filteredJson
+      
+      # Convert JSON into a simplified JSON.
+      resultJson="${{ steps.prepare-input.outputs.safe-image-id }}.result.json"
+      jq '{
+            image: "${{ inputs.image }}",
+            stats: {
+              Critical: { total: .cve.critical_vulnerabilities, fixable: .cve.critical_fixable_vulnerabilities },
+              High: { total: .cve.high_vulnerabilities, fixable: .cve.high_fixable_vulnerabilities },
+              Medium: { total: .cve.medium_vulnerabilities, fixable: .cve.medium_fixable_vulnerabilities },
+              Low: { total: .cve.low_vulnerabilities, fixable: .cve.low_fixable_vulnerabilities },
+              Info: { total: .cve.info_vulnerabilities, fixable: .cve.info_fixable_vulnerabilities }
+            },
+            includedSeverities: [ "Critical", "High" ], 
+            cves: [.cve.image.image_layers[].packages[] | . as $p | .vulnerabilities[]
+              | {cveId: .name, severity: .severity, package: $p.name, currentVersion: $p.version, fixVersion: .fix_version, status: .status, link: .link}]
+              | sort_by(.severity, .cveId)
+          }' $filteredJson > $resultJson
+      
+      # Set multiline output.
+      echo 'result-json<<EOF' >> $GITHUB_OUTPUT
+      cat $resultJson >> $GITHUB_OUTPUT
+      echo 'EOF' >> $GITHUB_OUTPUT
+
+  - name: Print result json (debug mode)
+    if: inputs.debug-mode == 'true'
+    shell: bash
+    run: |
+      echo "*** RESULT JSON:"
+      cat ${{ steps.prepare-input.outputs.safe-image-id }}.result.json
+
+  - name: Upload results to artifacts (debug mode)
+    if: inputs.debug-mode == 'true'
+    uses: actions/upload-artifact@v3
+    with:
+      name: ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-debuginfo
+      path: |
+        ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-report.html
+        ${{ steps.prepare-input.outputs.safe-image-id }}.result.json
+        ./evaluations/**/evaluation_*.json
+

--- a/.github/actions/action-lacework-scan/action.yml
+++ b/.github/actions/action-lacework-scan/action.yml
@@ -59,8 +59,6 @@ runs:
       IMAGE_TAG: ${{ steps.prepare-input.outputs.image-tag }}
       SCAN_LIBRARY_PACKAGES: true
       SAVE_RESULTS_IN_LACEWORK: ${{ inputs.save-results-in-lacework }}
-      SAVE_BUILD_REPORT: ${{ env.ACTIONS_STEP_DEBUG }}
-      BUILD_REPORT_FILE_NAME: ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-report.html
       LW_SCANNER_ENABLE_DEBUGGING: ${{ env.ACTIONS_STEP_DEBUG }}
 
 
@@ -114,14 +112,3 @@ runs:
     run: |
       echo "*** RESULT JSON:"
       cat ${{ steps.prepare-input.outputs.safe-image-id }}.result.json
-
-  - name: Upload results to artifacts (debug mode)
-    if: env.ACTIONS_STEP_DEBUG == 'true'
-    uses: actions/upload-artifact@v3
-    with:
-      name: ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-debuginfo
-      path: |
-        ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-report.html
-        ${{ steps.prepare-input.outputs.safe-image-id }}.result.json
-        ./evaluations/**/evaluation_*.json
-

--- a/.github/actions/action-lacework-scan/action.yml
+++ b/.github/actions/action-lacework-scan/action.yml
@@ -23,9 +23,6 @@ inputs:
   save-results-in-lacework:
     description: 'Save results to Lacework. (Default: false)'
     default: 'false'
-  debug-mode:
-    description: 'Set to "true" to enable debug mode. It generates extra artifacts with partial results. (Default: false)'
-    default: 'false'
 
 outputs:
   result-json:
@@ -62,9 +59,9 @@ runs:
       IMAGE_TAG: ${{ steps.prepare-input.outputs.image-tag }}
       SCAN_LIBRARY_PACKAGES: true
       SAVE_RESULTS_IN_LACEWORK: ${{ inputs.save-results-in-lacework }}
-      SAVE_BUILD_REPORT: ${{ inputs.debug-mode }}
+      SAVE_BUILD_REPORT: ${{ env.ACTIONS_STEP_DEBUG }}
       BUILD_REPORT_FILE_NAME: ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-report.html
-      LW_SCANNER_ENABLE_DEBUGGING: ${{ inputs.debug-mode }}
+      LW_SCANNER_ENABLE_DEBUGGING: ${{ env.ACTIONS_STEP_DEBUG }}
 
 
   - name: Process result
@@ -112,14 +109,14 @@ runs:
       echo 'EOF' >> $GITHUB_OUTPUT
 
   - name: Print result json (debug mode)
-    if: inputs.debug-mode == 'true'
+    if: env.ACTIONS_STEP_DEBUG == 'true'
     shell: bash
     run: |
       echo "*** RESULT JSON:"
       cat ${{ steps.prepare-input.outputs.safe-image-id }}.result.json
 
   - name: Upload results to artifacts (debug mode)
-    if: inputs.debug-mode == 'true'
+    if: env.ACTIONS_STEP_DEBUG == 'true'
     uses: actions/upload-artifact@v3
     with:
       name: ${{ steps.prepare-input.outputs.safe-image-id }}.lacework-debuginfo

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,202 @@
+name: Image Scan
+
+on:
+  workflow_call:
+    inputs:
+      images:
+        required: true
+        type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      LW_ACCOUNT_NAME:
+        required: true
+      LW_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  # Setup for matrix run.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      imagesJson: ${{ steps.setup.outputs.imagesJson }}
+    steps:
+    - id: setup
+      run: |
+        imagesJson=$(echo '${{ inputs.images }}' | sed -e 's/^/["/' -e 's/ /","/g' -e 's/$/"]/')
+        echo "imagesJson=$imagesJson" >> $GITHUB_OUTPUT
+
+  # Run Lacework scan for all images.
+  lacework-scan:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        image: ${{fromJson(needs.setup.outputs.imagesJson)}}
+    steps:
+    - name: Call Lacework scan
+      id: run-scan
+      # TODO simon: remove branch ref before merge!
+      uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@jsimon/image-scan
+      with:
+        image: ${{ matrix.image }}
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_PASSWORD }}
+        lw-account-name: ${{ secrets.LW_ACCOUNT_NAME }}
+        lw-access-token: ${{ secrets.LW_ACCESS_TOKEN }}
+        debug-mode: false
+
+    - name: Prepare the result for saving
+      id: prepare-save
+      run: |
+        safeImageId=$(echo "${{ matrix.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+        fileName=${safeImageId}.lacework-result.json
+        echo '${{ steps.run-scan.outputs.result-json }}' > $fileName
+        echo "file-name=$fileName" >> $GITHUB_OUTPUT
+
+    - name: Save the result as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.prepare-save.outputs.file-name }}
+        path: ${{ steps.prepare-save.outputs.file-name }}
+        if-no-files-found: error
+
+  # Evaluate scan results.
+  evaluate-results:
+    needs: [ lacework-scan ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all results from artifacts
+      uses: actions/download-artifact@v3
+
+    - name: Build and set job summary
+      shell: bash
+      run: |
+        lwResultFiles="$(find . -type f -name '*.lacework-result.json' | sort)"
+
+        echo "## <a name=\"scan-results\"></a>Lacework scan results" >> $GITHUB_STEP_SUMMARY
+        for jsonFile in $lwResultFiles; do
+          image=$(jq -r '.image' $jsonFile)
+          cveC=$(jq -r '.stats.Critical.total' $jsonFile)
+          cveH=$(jq -r '.stats.High.total' $jsonFile)
+          cveM=$(jq -r '.stats.Medium.total' $jsonFile)
+          cveL=$(jq -r '.stats.Low.total' $jsonFile)
+          cveI=$(jq -r '.stats.Info.total' $jsonFile)
+        
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### $image" >> $GITHUB_STEP_SUMMARY
+
+          # Highlight number in table cell.
+          _hln() {
+            if [ ${1} -gt 0 ]; then
+              echo "**${1}** :x:"
+            else
+              echo "${1} :heavy_check_mark:"
+            fi
+          }
+
+          echo "| Critical | High | Medium | Low | Info |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| $(_hln $cveC) | $(_hln $cveH) | $cveM | $cveL | $cveI |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Print CVE table (if not empty).
+          cveCount=$(jq -r '.cves | length' $jsonFile)
+          if [ $cveCount -gt 0 ]; then
+            echo "|CVE|Severity|Package|Current version|Fix version| Status|" >> $GITHUB_STEP_SUMMARY
+            echo "|---|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
+            for row in $(jq -r '.cves[] | @base64' $jsonFile); do
+              row=$(echo ${row} | base64 --decode)
+              _jq() {
+                echo $row | jq -r ${1}
+              }
+              echo "| [$(_jq '.cveId')]($(_jq '.link')) | $(_jq '.severity') | $(_jq '.package') | $(_jq '.currentVersion')|  | $(_jq '.status') |" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
+        done
+
+    - name: Build PR comment
+      if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      id: build-pr-comment
+      shell: bash
+      run: |
+        lwResultFiles="$(find . -type f -name '*.lacework-result.json' | sort)"
+        
+        # Collect overall status.
+        lwStatusIcon=":green_circle:"
+        for jsonFile in $lwResultFiles; do
+          cveC=$(jq -r '.stats.Critical.total' $jsonFile)
+          cveH=$(jq -r '.stats.High.total' $jsonFile)
+          if [ $cveC -gt 0 ] || [ $cveH -gt 0 ]; then
+            lwStatusIcon=":red_circle:"
+            break
+          fi
+        done
+
+        c="### ${lwStatusIcon}&nbsp; Lacework scan results:"
+        c="${c}\n| Image | Critical | High | Medium | Low | Info |"
+        c="${c}\n|---|---|---|---|---|---|"
+
+        # Highlight number in table cell.
+        _hln() {
+          if [ ${1} -gt 0 ]; then
+            echo "**${1}** :x:"
+          else
+            echo "${1} :heavy_check_mark:"
+          fi
+        }
+
+        for jsonFile in $lwResultFiles; do
+          image=$(jq -r '.image' $jsonFile)
+          cveC=$(jq -r '.stats.Critical.total' $jsonFile)
+          cveH=$(jq -r '.stats.High.total' $jsonFile)
+          cveM=$(jq -r '.stats.Medium.total' $jsonFile)
+          cveL=$(jq -r '.stats.Low.total' $jsonFile)
+          cveI=$(jq -r '.stats.Info.total' $jsonFile)
+          c="${c}\n| ${image} | $(_hln $cveC) | $(_hln $cveH) | $cveM | $cveL | $cveI |"
+        done
+
+        runUrl="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#user-content-scan-results"
+        c="${c}\n\n<sup>[Go to job summary for more details...]($runUrl)</sup>"
+
+        # Set multiline output.
+        echo 'comment<<EOF' >> $GITHUB_OUTPUT
+        echo -e "$c" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+
+    - name: Add PR comment (if content changed)
+      if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      uses: actions/github-script@v6
+      with:
+        retries: 3
+        retry-exempt-status-codes: 400,401
+        script: |
+          function removeLinks(body) {
+            return body.replace(/\]\(http[^)]+\)/gm, "](#)");
+          }
+
+          // Get the existing comments.
+          const {data: comments} = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.number,
+          })
+
+          // Find last bot comment.
+          const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
+
+          const newCommentBody = `${{ steps.build-pr-comment.outputs.comment }}`
+          if (!lastBotComment || removeLinks(newCommentBody)  !== removeLinks(lastBotComment.body)) {
+            // Add new comment.
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+              body: newCommentBody
+            })
+          } else {
+            console.log("No changes, nothing to do.")
+          }

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -47,7 +47,8 @@ jobs:
         docker-password: ${{ secrets.DOCKER_PASSWORD }}
         lw-account-name: ${{ secrets.LW_ACCOUNT_NAME }}
         lw-access-token: ${{ secrets.LW_ACCESS_TOKEN }}
-        debug-mode: false
+      env:
+        ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
 
     - name: Prepare the result for saving
       id: prepare-save

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -44,8 +44,7 @@ jobs:
     steps:
     - name: Call Lacework scan
       id: run-scan
-      # TODO simon: remove branch ref before merge!
-      uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@jsimon/image-scan
+      uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan
       with:
         image: ${{ matrix.image }}
         docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -113,7 +113,7 @@ jobs:
               _jq() {
                 echo $row | jq -r ${1}
               }
-              echo "| [$(_jq '.cveId')]($(_jq '.link')) | $(_jq '.severity') | $(_jq '.package') | $(_jq '.currentVersion')|  | $(_jq '.status') |" >> $GITHUB_STEP_SUMMARY
+              echo "| [$(_jq '.cveId')]($(_jq '.link')) | $(_jq '.severity') | $(_jq '.package') | $(_jq '.currentVersion') | $(_jq '.fixVersion') | $(_jq '.status') |" >> $GITHUB_STEP_SUMMARY
             done
           fi
         done

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -174,8 +174,11 @@ jobs:
         retries: 3
         retry-exempt-status-codes: 400,401
         script: |
-          function removeLinks(body) {
-            return body.replace(/\]\(http[^)]+\)/gm, "](#)");
+          function removeDynamicValues(body) {
+            // remove links and dynamic image tag hashes
+            return body
+               .replace(/\]\(http[^)]+\)/gm, "](#)")
+               .replace(/(docker\.io\/[^ ]+)-\w{7}/gm, "$1-#######")
           }
 
           // Get the existing comments.
@@ -189,7 +192,7 @@ jobs:
           const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
 
           const newCommentBody = `${{ steps.build-pr-comment.outputs.comment }}`
-          if (!lastBotComment || removeLinks(newCommentBody)  !== removeLinks(lastBotComment.body)) {
+          if (!lastBotComment || removeDynamicValues(newCommentBody)  !== removeDynamicValues(lastBotComment.body)) {
             // Add new comment.
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -136,9 +136,9 @@ jobs:
           fi
         done
 
-        c="### ${lwStatusIcon}&nbsp; Lacework scan results:"
-        c="${c}\n| Image | Critical | High | Medium | Low | Info |"
-        c="${c}\n|---|---|---|---|---|---|"
+        comment="### ${lwStatusIcon}&nbsp; Lacework scan results:"
+        comment="${comment}\n| Image | Critical | High | Medium | Low | Info |"
+        comment="${comment}\n|---|---|---|---|---|---|"
 
         # Highlight number in table cell.
         _hln() {
@@ -156,15 +156,15 @@ jobs:
           cveM=$(jq -r '.stats.Medium.total' $jsonFile)
           cveL=$(jq -r '.stats.Low.total' $jsonFile)
           cveI=$(jq -r '.stats.Info.total' $jsonFile)
-          c="${c}\n| ${image} | $(_hln $cveC) | $(_hln $cveH) | $cveM | $cveL | $cveI |"
+          comment="${comment}\n| ${image} | $(_hln $cveC) | $(_hln $cveH) | $cveM | $cveL | $cveI |"
         done
 
         runUrl="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#user-content-scan-results"
-        c="${c}\n\n<sup>[Go to job summary for more details...]($runUrl)</sup>"
+        comment="${comment}\n\n<sup>[Go to job summary for more details...]($runUrl)</sup>"
 
         # Set multiline output.
         echo 'comment<<EOF' >> $GITHUB_OUTPUT
-        echo -e "$c" >> $GITHUB_OUTPUT
+        echo -e "$comment" >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Add PR comment (if content changed)
@@ -192,7 +192,7 @@ jobs:
           const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
 
           const newCommentBody = `${{ steps.build-pr-comment.outputs.comment }}`
-          if (!lastBotComment || removeDynamicValues(newCommentBody)  !== removeDynamicValues(lastBotComment.body)) {
+          if (!lastBotComment || removeDynamicValues(newCommentBody) !== removeDynamicValues(lastBotComment.body)) {
             // Add new comment.
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -3,16 +3,21 @@ name: Image Scan
 on:
   workflow_call:
     inputs:
+      # Space-separated list of images.
       images:
         required: true
         type: string
     secrets:
+      # Docker username.
       DOCKER_USERNAME:
         required: true
+      # Docker password.
       DOCKER_PASSWORD:
         required: true
+      # Lacework account name.
       LW_ACCOUNT_NAME:
         required: true
+      # Lacework access token.
       LW_ACCESS_TOKEN:
         required: true
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Prerequisites to use:
 
 ### With explicit secrets
 
-The caller cannot use the `implicit` keyword if the caller workflow is not from the Portworx organization
+The caller cannot use the `inherit` keyword if the caller workflow is not from the Portworx organization
 ([doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit)).
 In this case the secrets must be defined explicitly:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The main goal this workflow is to:
 
 ## Usage
 
+### With inherited secrets
+
 ```yml
 jobs:
   # ...
@@ -22,8 +24,17 @@ jobs:
     secrets: inherit
 ```
 
-or with secrets explicitly defined if the caller workflow is not from a Portworx repo 
-([doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit)):
+Prerequisites to use:
+
+* The caller repository must be under the Portworx organization.
+* The caller repository must have added all the secrets defined in the [Inputs](#inputs) section below (using the same
+  names).
+
+### With explicit secrets
+
+The caller cannot use the `implicit` keyword if the caller workflow is not from the Portworx organization
+([doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit)).
+In this case the secrets must be defined explicitly:
 
 ```yml
 jobs:
@@ -38,7 +49,7 @@ jobs:
       LW_ACCESS_TOKEN: ${{ secrets.LW_ACCESS_TOKEN }}
 ```
 
-## Inputs
+## <a id="inputs"></a>Inputs
 
 ```yml
     inputs:
@@ -64,6 +75,7 @@ jobs:
 ## Outputs
 
 * Image scan results are:
-  * visualized in the job summary section,
-  * visualized in a pull request comment (if the scan result is different from the previous),
-  * uploaded as artifacts into workflow run page as separate JSON files per image (e.g. `docker.io-portworx-pds-base-config-ubi8-a2aee61.lacework-result.json`).
+    * visualized in the job summary section,
+    * visualized in a pull request comment (if the scan result is different from the previous),
+    * uploaded as artifacts into workflow run page as separate JSON files per image (
+      e.g. `docker.io-portworx-pds-base-config-ubi8-a2aee61.lacework-result.json`).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# workflow-image-scan
+# Reusable GitHub Workflow to Scan Images
+
+> This workflow is highly specific for a few Portworx-internal repositories - may not be suited for generic usage.
+
+The main goal this workflow is to:
+
+1. call Lacework scanner action ([lacework/lw-scanner-action](https://github.com/lacework/lw-scanner-action)) for the
+   input images,
+2. builds a scan result summary section and adds it to the end of the Actions run page,
+3. adds a comment into the pull request containing the scan results in short form.
+
+## Usage
+
+```yml
+jobs:
+  # ...
+  image-scan:
+    needs: [ other-job1, other-job2 ]
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml
+    with:
+      images: ${{ needs.other-job1.outputs.image }} ${{ needs.other-job2.outputs.image }}
+    secrets: inherit
+```
+
+or with explicit secrets:
+
+```yml
+jobs:
+  image-scan:
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml
+    with:
+      images: 'docker.io/busybox:1.35.0' 'docker.io/redhat/ubi8:8.6'
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}
+      LW_ACCESS_TOKEN: ${{ secrets.LW_ACCESS_TOKEN }}
+```
+
+## Inputs
+
+```yml
+    inputs:
+      # Space-separated list of images (e.g. "docker.io/busybox:1.35.0 docker.io/redhat/ubi8:8.6").
+      images:
+        required: true
+        type: string
+    secrets:
+      # Docker username.
+      DOCKER_USERNAME:
+        required: true
+      # Docker password.
+      DOCKER_PASSWORD:
+        required: true
+      # Lacework account name.
+      LW_ACCOUNT_NAME:
+        required: true
+      # Lacework access token.
+      LW_ACCESS_TOKEN:
+        required: true
+```
+
+## Outputs
+
+Image scan results visualized in:
+
+1. job summary section,
+2. pull request comment.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 The main goal this workflow is to:
 
-1. call Lacework scanner action ([lacework/lw-scanner-action](https://github.com/lacework/lw-scanner-action)) for the
-   input images,
-2. builds a scan result summary section and adds it to the end of the Actions run page,
-3. adds a comment into the pull request containing the scan results in short form.
+1. Call Lacework scanner action ([lacework/lw-scanner-action](https://github.com/lacework/lw-scanner-action)) for the
+   input images.
+2. Build a scan result summary section and add it to the end of the Actions run page.
+3. Add a comment into the pull request containing the scan results in short form.
 
 ## Usage
 
@@ -22,7 +22,8 @@ jobs:
     secrets: inherit
 ```
 
-or with explicit secrets:
+or with secrets explicitly defined if the caller workflow is not from a Portworx repo 
+([doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit)):
 
 ```yml
 jobs:
@@ -62,7 +63,7 @@ jobs:
 
 ## Outputs
 
-Image scan results visualized in:
-
-1. job summary section,
-2. pull request comment.
+* Image scan results are:
+  * visualized in the job summary section,
+  * visualized in a pull request comment (if the scan result is different from the previous),
+  * uploaded as artifacts into workflow run page as separate JSON files per image (e.g. `docker.io-portworx-pds-base-config-ubi8-a2aee61.lacework-result.json`).


### PR DESCRIPTION
**What this PR does / why we need it**:

Add initial workflow to scan images with Lacework scan. The PR contains:
1. a new github action `action-lacework-scan` to scan an image with external Lacework scanner (`lacework/lw-scanner-action`)
2. a new workflow `image-scan.yml` that:
    1. calls Lacework scan of ALL provided images (in parallel)
    2. builds a result summary section and adds it to the end of the Actions run page
    3. adds a new PR comment with short summary (adds only after the first run and if the scan results have changed)
