### PR TITLE
DS-3184: Revert local actions

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -57,10 +57,9 @@ jobs:
       matrix:
         image: ${{fromJson(needs.setup.outputs.imagesJson)}}
     steps:
-      - uses: actions/checkout@v2.3.4 # Necessary to access local action
       - name: Call Lacework scan
         id: run-scan
-        uses: ./.github/actions/action-lacework-scan/
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.0.2
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -94,10 +93,9 @@ jobs:
       matrix:
         image: ${{fromJson(needs.setup.outputs.imagesJson)}}
     steps:
-      - uses: actions/checkout@v2.3.4 # Necessary to access local action
       - name: Call Aqua scan
         id: run-scan
-        uses: ./.github/actions/action-aqua-scan/
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.0.2
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Local actions have proven not to be a clean solution due to limited features of reusable workflows.
