### PR TITLE
Remove specific registry login

### DIFF
--- a/.github/actions/action-aqua-scan/action.yml
+++ b/.github/actions/action-aqua-scan/action.yml
@@ -42,11 +42,7 @@ runs:
       id: prepare-input
       shell: bash
       run: |
-        echo "image-name-no-registry=$(echo "${{ inputs.image }}" | cut -d: -f1 | cut -d/ -f2-)" >> $GITHUB_OUTPUT
-        echo "image-registry=$(echo "${{ inputs.image }}" | cut -d/ -f1 )" >> $GITHUB_OUTPUT
-        echo "image-tag=$(echo "${{ inputs.image }}" | cut -d: -f2)" >> $GITHUB_OUTPUT
-        echo "safe-image-id=$(echo "${{ inputs.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')" >> $GITHUB_OUTPUT
-    
+        echo "safe-image-id=$(echo "${{ inputs.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')" >> $GITHUB_OUTPUT    
 
     # try only once to pull the aquasec image
     - name: Aquasec registry login
@@ -76,7 +72,7 @@ runs:
         mkdir -p evaluations
         docker run -v "$PWD/evaluations:/evaluations" -v "/var/run/docker.sock:/var/run/docker.sock" "${{ inputs.aqua-image }}" \
         scan --token "${{ inputs.aqua-access-token }}" --host "${{ inputs.aquasec-server-url }}" \
-        --local --show-negligible --jsonfile /evaluations/evaluation_"${{ steps.prepare-input.outputs.safe-image-id }}".json "${{ steps.prepare-input.outputs.image-name-no-registry }}:${{ steps.prepare-input.outputs.image-tag }}" || \
+        --show-negligible --jsonfile /evaluations/evaluation_"${{ steps.prepare-input.outputs.safe-image-id }}".json --local "${{ inputs.image }}" || \
         true
         # the || true  is needed because the aquasec scan returns non zero exit code when there are policy violations,
         # but still generates a valid json file with the results
@@ -108,8 +104,8 @@ runs:
         
         # Check image is the same.
         image=$(cat $fullJson | jq -r '.image')
-        if [ "$image" != "${{ steps.prepare-input.outputs.image-name-no-registry }}:${{ steps.prepare-input.outputs.image-tag }}" ]; then
-          >&2 echo "Image mismatch: ${image} != ${{ steps.prepare-input.outputs.image-name-no-registry }}:${{ steps.prepare-input.outputs.image-tag }}"
+        if [ "$image" != "${{ inputs.image }}" ]; then
+          >&2 echo "Image mismatch: ${image} != ${{ inputs.image }}"
           exit 1
         fi
         

--- a/.github/actions/action-aqua-scan/action.yml
+++ b/.github/actions/action-aqua-scan/action.yml
@@ -63,7 +63,6 @@ runs:
     - name: Docker login
       uses: docker/login-action@v2
       with:
-        registry: ${{ steps.prepare-input.outputs.image-registry }}
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
 

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.1
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.2
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.1
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.2
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+WORKFLOW_VERSION=v2.1.2
+
+.PHONY: update-version
+update-version:
+	sed -i -E "s/(image-scan.yml@v.+)/image-scan.yml@$(WORKFLOW_VERSION)/g" README.md;
+	sed -i -E "s/(scan@v.+)/scan@$(WORKFLOW_VERSION)/g" .github/workflows/image-scan.yml;
+	git add README.md .github/workflows/image-scan.yml Makefile;
+	git commit -m "Update version to $(WORKFLOW_VERSION)";
+	git tag --force "$(WORKFLOW_VERSION)" HEAD ; # don't forget to push the tag

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
   # ...
   image-scan:
     needs: [ other-job1, other-job2 ]
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.0.0
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.2
     with:
       images: ${{ needs.other-job1.outputs.image }} ${{ needs.other-job2.outputs.image }}
     secrets: inherit
@@ -46,7 +46,7 @@ In this case the secrets must be defined explicitly:
 ```yml
 jobs:
   image-scan:
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.0.0
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.2
     with:
       images: 'docker.io/busybox:1.35.0' 'docker.io/redhat/ubi8:8.6'
     secrets:


### PR DESCRIPTION
**What this PR does / why we need it**:
When images from multiple registries are scanned in a single GitHub repository, aqua fails on login - using credentials meant for another registry. Here I just mimic the lacework action and remove the specific login. Dedicated credentials functionality can be added at a later point.

Additionally, using local images enables using registries not predefined in Aqua console. (Needed for `gcr.io` based images.)

**Which issue(s) this PR fixes**
Closes [#DS-4166](https://portworx.atlassian.net/browse/DS-4166)
