### PR TITLE
Cut docker from img names

### DIFF
--- a/.github/actions/action-aqua-scan/action.yml
+++ b/.github/actions/action-aqua-scan/action.yml
@@ -42,7 +42,9 @@ runs:
       id: prepare-input
       shell: bash
       run: |
-        echo "safe-image-id=$(echo "${{ inputs.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')" >> $GITHUB_OUTPUT    
+        echo "safe-image-id=$(echo "${{ inputs.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')" >> $GITHUB_OUTPUT
+        RAW_IMAGE="${{ inputs.image }}"
+        echo "image-name=${RAW_IMAGE#'docker.io/'}" >> $GITHUB_OUTPUT
 
     # try only once to pull the aquasec image
     - name: Aquasec registry login

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.2
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.4
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.2
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.4
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-WORKFLOW_VERSION=v2.1.2
+WORKFLOW_VERSION=v2.1.4
 
 .PHONY: update-version
 update-version:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
   # ...
   image-scan:
     needs: [ other-job1, other-job2 ]
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.2
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.4
     with:
       images: ${{ needs.other-job1.outputs.image }} ${{ needs.other-job2.outputs.image }}
     secrets: inherit
@@ -46,7 +46,7 @@ In this case the secrets must be defined explicitly:
 ```yml
 jobs:
   image-scan:
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.2
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.4
     with:
       images: 'docker.io/busybox:1.35.0' 'docker.io/redhat/ubi8:8.6'
     secrets:


### PR DESCRIPTION
**What this PR does / why we need it**:
Cutting `docker.io` from name of scanned image, because docker cuts it when pulling from DockerHub.
**Which issue(s) this PR fixes** (optional)
Closes [#DS-4465](https://portworx.atlassian.net/browse/DS-4465)

