### PR TITLE
DS-4281: Target branch scan result comparison

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -546,7 +546,7 @@ jobs:
         with:
           retries: 3
           retry-exempt-status-codes: 400,401
-          script: |          
+          script: |
             function removeDynamicValues(body) {
               // remove links and dynamic image tag hashes
               return body
@@ -560,7 +560,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.number,
             })
-                  
+
             // Find last bot comment.
             const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
             

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -533,13 +533,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: comment
-          
+
       - name: Download comment-target
-        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' }}
+        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' && needs.evaluate-target-results.result != 'Skipped' }}
         uses: actions/download-artifact@v3
         with:
           name: comment-target
-        
+
       - name: Add PR comment (if content changed)
         if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
         uses: actions/github-script@v6

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -535,6 +535,7 @@ jobs:
           name: comment
           
       - name: Download comment-target
+        if: ${{ !cancelled() && needs.evaluate-target-results.result == 'success' }}
         uses: actions/download-artifact@v3
         with:
           name: comment-target

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -39,9 +39,9 @@ on:
 jobs:
   # Setup for matrix run.
   setup:
+    runs-on: ubuntu-latest
     outputs:	
       imagesJson: ${{ steps.setup.outputs.imagesJson }}
-    runs-on: ubuntu-latest
     steps:
       - id: setup
         run: |
@@ -129,7 +129,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:	
       vulnerable: ${{ steps.job-summary.outputs.vulnerable }}
-      comment: ${{ steps.build-pr-commment.outputs.comment }}
     steps:
       - name: Download all results from artifacts
         uses: actions/download-artifact@v3
@@ -383,8 +382,6 @@ jobs:
   # Evaluate scan results for the target branch.
   evaluate-target-results:
     needs: [ lacework-scan-target, aqua-scan-target ]
-    outputs:	
-      comment2: ${{ steps.build-pr-commment.outputs.comment }}
     runs-on: ubuntu-latest
     steps:
       - name: Download all results from artifacts
@@ -567,10 +564,12 @@ jobs:
             const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
             
             const fs = require('fs');
-            const comment = fs.readFileSync('comment.txt', 'utf8');
-            const commentTarget = fs.readFileSync('comment-target.txt', 'utf8');
-            const newCommentBody = `${comment}\n\n${commentTarget}`.replace(/\\n/g, "\n");
-            console.log(newCommentBody);
+            let newCommentBody = fs.readFileSync('comment.txt', 'utf8');
+            if (fs.existsSync('comment-target.txt')) {
+              const commentTarget = fs.readFileSync('comment-target.txt', 'utf8');
+              newCommentBody = `${newCommentBody}\n\n${commentTarget}`;
+            }
+            newcommentBody = newcommentBody.replace(/\\n/g, "\n");
 
             if (!lastBotComment || removeDynamicValues(newCommentBody) !== removeDynamicValues(lastBotComment.body)) {
               // Add new comment.

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -535,7 +535,7 @@ jobs:
           name: comment
           
       - name: Download comment-target
-        if: ${{ !cancelled() && needs.evaluate-target-results.result == 'success' }}
+        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' }}
         uses: actions/download-artifact@v3
         with:
           name: comment-target

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.8
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.7
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.8
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.7
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -314,7 +314,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.8
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.7
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -351,7 +351,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.8
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.7
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -526,7 +526,7 @@ jobs:
   # Add a PR comment if the contents changed
   add-pr-comment:
     needs: [ evaluate-results, evaluate-target-results ]
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') }}
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Download comment
@@ -535,7 +535,7 @@ jobs:
           name: comment
 
       - name: Download comment-target
-        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' }}
+        if: always() && !cancelled() && needs.evaluate-target-results.result == 'success'
         uses: actions/download-artifact@v3
         with:
           name: comment-target

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -560,7 +560,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.number,
             })
-
+            
             // Find last bot comment.
             const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
             

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -535,7 +535,7 @@ jobs:
           name: comment
 
       - name: Download comment-target
-        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' && needs.evaluate-target-results.result != 'skipped' }}
+        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' }}
         uses: actions/download-artifact@v3
         with:
           name: comment-target

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -570,7 +570,7 @@ jobs:
               const commentTarget = fs.readFileSync('comment-target.txt', 'utf8');
               newCommentBody = `${newCommentBody}\n\n${commentTarget}`;
             }
-            newcommentBody = newcommentBody.replace(/\\n/g, "\n");
+            newCommentBody = newCommentBody.replace(/\\n/g, "\n");
 
             if (!lastBotComment || removeDynamicValues(newCommentBody) !== removeDynamicValues(lastBotComment.body)) {
               // Add new comment.

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -40,7 +40,7 @@ jobs:
   # Setup for matrix run.
   setup:
     runs-on: ubuntu-latest
-    outputs:	
+    outputs:
       imagesJson: ${{ steps.setup.outputs.imagesJson }}
     steps:
       - id: setup

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Build and set job summary
         id: job-summary
         shell: bash
-        run: |          
+        run: |
           # Highlight number in table cell.
           _hln() {
             if [ ${1} -gt 0 ]; then

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -529,16 +529,16 @@ jobs:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
+      - name: Download comment
+        uses: actions/download-artifact@v3
+        with:
+          name: comment
+
       - name: Whatever
         shell: bash
         run: |
           echo '${{ needs.evaluate-target-results.result }}' >> $GITHUB_STEP_SUMMARY
           echo '${{ needs }}' >> $GITHUB_STEP_SUMMARY
-    
-      - name: Download comment
-        uses: actions/download-artifact@v3
-        with:
-          name: comment
 
       - name: Download comment-target
         if: always() && !cancelled() && needs.evaluate-target-results.result == 'success'

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -535,7 +535,7 @@ jobs:
           name: comment
 
       - name: Download comment-target
-        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' && needs.evaluate-target-results.result != 'Skipped' }}
+        if: ${{ always() && !cancelled() && needs.evaluate-target-results.result == 'success' && needs.evaluate-target-results.result != 'skipped' }}
         uses: actions/download-artifact@v3
         with:
           name: comment-target

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -529,6 +529,12 @@ jobs:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
+      - name: Whatever
+        shell: bash
+        run: |
+          echo '${{ needs.evaluate-target-results.result }}' >> $GITHUB_STEP_SUMMARY
+          echo '${{ needs }}' >> $GITHUB_STEP_SUMMARY
+    
       - name: Download comment
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.7
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.2.0
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.7
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.2.0
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -314,7 +314,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.7
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.2.0
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -351,7 +351,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.7
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.2.0
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -534,12 +534,6 @@ jobs:
         with:
           name: comment
 
-      - name: Whatever
-        shell: bash
-        run: |
-          echo '${{ needs.evaluate-target-results.result }}' >> $GITHUB_STEP_SUMMARY
-          echo '${{ needs }}' >> $GITHUB_STEP_SUMMARY
-
       - name: Download comment-target
         if: always() && !cancelled() && needs.evaluate-target-results.result == 'success'
         uses: actions/download-artifact@v3

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -39,9 +39,9 @@ on:
 jobs:
   # Setup for matrix run.
   setup:
-    runs-on: ubuntu-latest
-    outputs:
+    outputs:	
       imagesJson: ${{ steps.setup.outputs.imagesJson }}
+    runs-on: ubuntu-latest
     steps:
       - id: setup
         run: |
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Call Lacework scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.7
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.8
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Call Aqua scan
         id: run-scan
-        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.7
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.8
         with:
           image: ${{ matrix.image }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
@@ -127,13 +127,17 @@ jobs:
   evaluate-results:
     needs: [ lacework-scan, aqua-scan ]
     runs-on: ubuntu-latest
+    outputs:	
+      vulnerable: ${{ steps.job-summary.outputs.vulnerable }}
+      comment: ${{ steps.build-pr-commment.outputs.comment }}
     steps:
       - name: Download all results from artifacts
         uses: actions/download-artifact@v3
 
       - name: Build and set job summary
+        id: job-summary
         shell: bash
-        run: |
+        run: |          
           # Highlight number in table cell.
           _hln() {
             if [ ${1} -gt 0 ]; then
@@ -166,6 +170,7 @@ jobs:
               # Print Vulnerability table (if not empty).
               cveCount=$(jq -r '.vulnerabilities | length' $resultJSONFile)
               if [ $cveCount -gt 0 ]; then
+                echo "vulnerable=1" >> $GITHUB_OUTPUT
                 if [ "$2" = "aqua" ]; then
                   echo "|Vulnerability|Severity|Package|Current version|Path|Fix version|" >> $GITHUB_STEP_SUMMARY
                   echo "|---|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
@@ -257,19 +262,293 @@ jobs:
         
           runUrl="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#user-content-scan-results"
           comment="${comment}\n\n<sup>[Go to job summary for more details...]($runUrl)</sup>"
-          
-          # Set multiline output.
-          echo 'comment<<EOF' >> $GITHUB_OUTPUT
-          echo -e "$comment" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo $comment > comment.txt
 
+      - name: Save the result as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: comment
+          path: comment.txt
+          if-no-files-found: error
+
+  setup-target:
+    needs: [ setup, evaluate-results ]
+    if: needs.evaluate-results.outputs.vulnerable == 1
+    runs-on: ubuntu-latest
+    outputs:	
+      imagesJson: ${{ steps.setup.outputs.imagesJson }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Get latest commit hash
+        id: hash
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          echo "SHORT_SHA=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - id: setup
+        run: |
+          imagesJson=${{needs.setup.outputs.imagesJson}}       
+
+          IFS=',' read -ra images <<< "${imagesJson:1:-1}"
+          for i in "${!images[@]}"; do
+            images[$i]="${images[$i]::-7}${{steps.hash.outputs.SHORT_SHA}}"
+          done
+          
+          updatedImagesJson="$(printf "\"%s\"," "${images[@]}")"
+          updatedImagesJson="[${updatedImagesJson%,}]"
+
+          echo "imagesJson=$updatedImagesJson" >> $GITHUB_OUTPUT
+
+  # Run Lacework scan for all images.
+  lacework-scan-target:
+    needs: [ setup-target, evaluate-results ]
+    if: needs.evaluate-results.outputs.vulnerable == 1
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        image: ${{fromJson(needs.setup-target.outputs.imagesJson)}}
+    steps:
+      - name: Call Lacework scan
+        id: run-scan
+        uses: portworx/workflow-image-scan/.github/actions/action-lacework-scan@v2.1.8
+        with:
+          image: ${{ matrix.image }}
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          lw-account-name: ${{ secrets.LW_ACCOUNT_NAME }}
+          lw-access-token: ${{ secrets.LW_ACCESS_TOKEN }}
+        env:
+          ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+
+      - name: Prepare the result for saving
+        id: prepare-save
+        run: |
+          safeImageId=$(echo "${{ matrix.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+          fileName=${safeImageId}.lacework-result-target.json
+          echo '${{ steps.run-scan.outputs.result-json }}' > $fileName
+          echo "file-name=$fileName" >> $GITHUB_OUTPUT
+
+      - name: Save the result as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.prepare-save.outputs.file-name }}
+          path: ${{ steps.prepare-save.outputs.file-name }}
+          if-no-files-found: error
+
+  # Run Aqua scan for all images.
+  aqua-scan-target:
+    needs: [ setup-target, evaluate-results ]
+    if: needs.evaluate-results.outputs.vulnerable == 1
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        image: ${{fromJson(needs.setup-target.outputs.imagesJson)}}
+    steps:
+      - name: Call Aqua scan
+        id: run-scan
+        uses: portworx/workflow-image-scan/.github/actions/action-aqua-scan@v2.1.8
+        with:
+          image: ${{ matrix.image }}
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          aqua-account-name: ${{ secrets.AQUA_ACCOUNT_NAME }}
+          aqua-account-password: ${{ secrets.AQUA_ACCOUNT_PASS }}
+          aqua-access-token: ${{ secrets.AQUA_ACCESS_TOKEN }}
+          aquasec-server-url: ${{ secrets.AQUASEC_SERVER_URL }}
+          aqua-image: ${{ secrets.AQUA_IMAGE }}
+        env:
+          ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+
+      - name: Prepare the result for saving
+        id: prepare-save
+        run: |
+          safeImageId=$(echo "${{ matrix.image }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+          fileName=${safeImageId}.aqua-result-target.json
+          echo '${{ steps.run-scan.outputs.result-json }}' > $fileName
+          echo "file-name=$fileName" >> $GITHUB_OUTPUT
+
+      - name: Save the result as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.prepare-save.outputs.file-name }}
+          path: ${{ steps.prepare-save.outputs.file-name }}
+          if-no-files-found: error
+
+  # Evaluate scan results for the target branch.
+  evaluate-target-results:
+    needs: [ lacework-scan-target, aqua-scan-target ]
+    outputs:	
+      comment2: ${{ steps.build-pr-commment.outputs.comment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all results from artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Build and set job summary
+        id: job-summary
+        shell: bash
+        run: |
+          # Highlight number in table cell.
+          _hln() {
+            if [ ${1} -gt 0 ]; then
+              echo "**${1}** :x:"
+            else
+              echo "${1} :heavy_check_mark:"
+            fi
+          }
+          _jq() {
+            echo $row | jq -r ${1}
+          }
+          summaryForScanner() {
+            for resultJSONFile in $1; do
+              image=$(jq -r '.image' $resultJSONFile)
+              detailedArtifactName=$(echo $image | sed 's/[^a-zA-Z0-9.-]/-/g')-$2-scan-detailed-result.json
+              cveC=$(jq -r '.stats.Critical.total' $resultJSONFile)
+              cveH=$(jq -r '.stats.High.total' $resultJSONFile)
+              cveM=$(jq -r '.stats.Medium.total' $resultJSONFile)
+              cveL=$(jq -r '.stats.Low.total' $resultJSONFile)
+              cveI=$(jq -r '.stats.Info.total' $resultJSONFile)
+          
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### $image" >> $GITHUB_STEP_SUMMARY
+              echo "###### Detailed scan result was stored as an artifact named: \`"$detailedArtifactName"\`" >> $GITHUB_STEP_SUMMARY
+              echo "| Critical | High | Medium | Low | Info |" >> $GITHUB_STEP_SUMMARY
+              echo "|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
+              echo "| $(_hln $cveC) | $(_hln $cveH) | $cveM | $cveL | $cveI |" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+          
+              # Print Vulnerability table (if not empty).
+              cveCount=$(jq -r '.vulnerabilities | length' $resultJSONFile)
+              if [ $cveCount -gt 0 ]; then
+                if [ "$2" = "aqua" ]; then
+                  echo "|Vulnerability|Severity|Package|Current version|Path|Fix version|" >> $GITHUB_STEP_SUMMARY
+                  echo "|---|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
+                  for row in $(jq -r '.vulnerabilities[] | @base64' $resultJSONFile); do
+                    row=$(echo ${row} | base64 --decode)
+                    echo "| [$(_jq '.vulnId')]($(_jq '.link')) | $(_jq '.severity') | $(_jq '.package') | $(_jq '.currentVersion') | $(_jq '.path') | $(_jq '.fixVersion') |" >> $GITHUB_STEP_SUMMARY
+                  done
+                else
+                  echo "|Vulnerability|Severity|Package|Current version| Path |Fix version|Status|" >> $GITHUB_STEP_SUMMARY
+                  echo "|---|---|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
+                  for row in $(jq -r '.vulnerabilities[] | @base64' $resultJSONFile); do
+                  row=$(echo ${row} | base64 --decode)
+                  echo "| [$(_jq '.vulnId')]($(_jq '.link')) | $(_jq '.severity') | $(_jq '.package') | $(_jq '.currentVersion') | $(_jq '.path') | $(_jq '.fixVersion') | $(_jq '.status') |" >> $GITHUB_STEP_SUMMARY
+                  done
+                fi
+              fi
+              policyFailureCount=$(jq -r '.policyFailures | length' $resultJSONFile)
+              if [ $policyFailureCount -gt 0 ]; then
+                echo "#### Policy failures" >> $GITHUB_STEP_SUMMARY
+                echo "|Policy Id| Policy Name |Blocking|" >> $GITHUB_STEP_SUMMARY
+                echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+                for row in $(jq -r '.policyFailures[] | @base64' $resultJSONFile); do
+                  row=$(echo ${row} | base64 --decode)
+                  blocking=$(_jq '.blocking')
+                  blockingSign=$(if [ $blocking = "Yes" ]; then echo ":x:"; fi) 
+                  echo "| $(_jq '.policyId') | $(_jq '.policyName') | $blocking $blockingSign |" >> $GITHUB_STEP_SUMMARY
+                done
+              fi
+            done
+          }
+          lwResultFiles="$(find . -type f -name '*.lacework-result-target.json' | sort)"
+          aquaResultFiles="$(find . -type f -name '*.aqua-result-target.json' | sort)"
+          echo "## <a name=\"scan-results\"></a>Target branch Lacework scan results" >> $GITHUB_STEP_SUMMARY
+          summaryForScanner "$lwResultFiles" "lw"
+          echo "## <a name=\"scan-results\"></a>Target branch Aqua scan results" >> $GITHUB_STEP_SUMMARY
+          summaryForScanner "$aquaResultFiles" "aqua"
+
+      - name: Build PR comment
+        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+        id: build-pr-comment
+        shell: bash
+        run: |
+          createPRCommentTable() {
+            comment="${comment}\n| Image | Critical | High | Medium | Low | Info | Policy failures |"
+            comment="${comment}\n|---|---|---|---|---|---|---|"
+          
+            for resultJSONFile in $1; do
+              image=$(jq -r '.image' $resultJSONFile)
+              cveC=$(jq -r '.stats.Critical.total' $resultJSONFile)
+              cveH=$(jq -r '.stats.High.total' $resultJSONFile)
+              cveM=$(jq -r '.stats.Medium.total' $resultJSONFile)
+              cveL=$(jq -r '.stats.Low.total' $resultJSONFile)
+              cveI=$(jq -r '.stats.Info.total' $resultJSONFile)
+              policyFailures=$(jq -r '.policyFailures | length' $resultJSONFile)
+              comment="${comment}\n| ${image} | $(_hln $cveC) | $(_hln $cveH) | $cveM | $cveL | $cveI |  $(_hln $policyFailures) |"
+            done
+          }
+          setStatusIcon(){
+            statusIcon=":green_circle:"
+            for resultJSONFile in $1; do
+              cveC=$(jq -r '.stats.Critical.total' $resultJSONFile)
+              cveH=$(jq -r '.stats.High.total' $resultJSONFile)
+              policyFailures=$(jq -r '.policyFailures | length' $resultJSONFile)
+              if [ $cveC -gt 0 ] || [ $cveH -gt 0 ] || [ $policyFailures -gt 0 ]; then
+                statusIcon=":red_circle:"
+                break
+              fi
+            done       
+          }
+          # Highlight number in table cell.
+          _hln() {
+            if [ ${1} -gt 0 ]; then
+              echo "**${1}** :x:"
+            else
+              echo "${1} :heavy_check_mark:"
+            fi
+          }   
+          lwResultFiles="$(find . -type f -name '*.lacework-result-target.json' | sort)"
+          
+          setStatusIcon "$lwResultFiles"
+          comment="### ${statusIcon}&nbsp; Target branch Lacework scan results:"
+          createPRCommentTable "$lwResultFiles"
+          
+          aquaResultFiles="$(find . -type f -name '*.aqua-result-target.json' | sort)"
+          
+          setStatusIcon "$aquaResultFiles"
+          comment="${comment}\n### ${statusIcon}&nbsp; Target branch Aqua scan results:"
+          createPRCommentTable "$aquaResultFiles"
+        
+          runUrl="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#user-content-scan-results"
+          comment="${comment}\n\n<sup>[Go to job summary for more details...]($runUrl)</sup>"
+          echo $comment > comment-target.txt
+
+      - name: Save the result as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: comment-target
+          path: comment-target.txt
+          if-no-files-found: error
+            
+  # Add a PR comment if the contents changed
+  add-pr-comment:
+    needs: [ evaluate-results, evaluate-target-results ]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download comment
+        uses: actions/download-artifact@v3
+        with:
+          name: comment
+          
+      - name: Download comment-target
+        uses: actions/download-artifact@v3
+        with:
+          name: comment-target
+        
       - name: Add PR comment (if content changed)
         if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
         uses: actions/github-script@v6
         with:
           retries: 3
           retry-exempt-status-codes: 400,401
-          script: |
+          script: |          
             function removeDynamicValues(body) {
               // remove links and dynamic image tag hashes
               return body
@@ -283,11 +562,16 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.number,
             })
-            
+                  
             // Find last bot comment.
             const lastBotComment = comments.slice().reverse().find(comment => comment.user.login === 'github-actions[bot]')
             
-            const newCommentBody = `${{ steps.build-pr-comment.outputs.comment }}`
+            const fs = require('fs');
+            const comment = fs.readFileSync('comment.txt', 'utf8');
+            const commentTarget = fs.readFileSync('comment-target.txt', 'utf8');
+            const newCommentBody = `${comment}\n\n${commentTarget}`.replace(/\\n/g, "\n");
+            console.log(newCommentBody);
+
             if (!lastBotComment || removeDynamicValues(newCommentBody) !== removeDynamicValues(lastBotComment.body)) {
               // Add new comment.
               await github.rest.issues.createComment({

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-WORKFLOW_VERSION=v2.1.8
+WORKFLOW_VERSION=v2.2.0
 
 .PHONY: update-version
 update-version:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-WORKFLOW_VERSION=v2.1.7
+WORKFLOW_VERSION=v2.1.8
 
 .PHONY: update-version
 update-version:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
   # ...
   image-scan:
     needs: [ other-job1, other-job2 ]
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.8
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.2.0
     with:
       images: ${{ needs.other-job1.outputs.image }} ${{ needs.other-job2.outputs.image }}
     secrets: inherit
@@ -46,7 +46,7 @@ In this case the secrets must be defined explicitly:
 ```yml
 jobs:
   image-scan:
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.8
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.2.0
     with:
       images: 'docker.io/busybox:1.35.0' 'docker.io/redhat/ubi8:8.6'
     secrets:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
   # ...
   image-scan:
     needs: [ other-job1, other-job2 ]
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.6
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.8
     with:
       images: ${{ needs.other-job1.outputs.image }} ${{ needs.other-job2.outputs.image }}
     secrets: inherit
@@ -46,7 +46,7 @@ In this case the secrets must be defined explicitly:
 ```yml
 jobs:
   image-scan:
-    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.6
+    uses: portworx/workflow-image-scan/.github/workflows/image-scan.yml@v2.1.8
     with:
       images: 'docker.io/busybox:1.35.0' 'docker.io/redhat/ubi8:8.6'
     secrets:


### PR DESCRIPTION
https://portworx.atlassian.net/browse/DS-4281

How things would work after this PR:
The PR build is scanned first. 
If there are no vulnerabilities, a comment is posted in the PR saying it's not vulnerable.
If there are vulnerabilities, the target branch build is scanned and a comment is posted in the PR showing the report from the PR scan and from the target branch scan. It'd look something like this if a new vulnerability is introduced:
![image](https://github.com/portworx/workflow-image-scan/assets/8254243/05b27457-7672-4911-ad2b-e07758b2d44e)


When a commit is made to a PR, a comment is posted only when the comment would differ from the last comment with the scan results.

When I spoke with Marek, we agreed that this is good enough.

There isn't a diff-only output for 2 reasons: 
1. I was unable to introduce a vulnerability to a PR to see what a scan result with vulnerabilities looks like.
2. It's beyond my bash skills to reverse-engineer how a scan result with vulnerabilities would look like from the existing code and write new code for doing a diff that would work without testing it with a real scan result a single time.